### PR TITLE
27 implement weighted grade in course evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ dependencies:
 
 ## Usage
 
-To use this library you can create an instance of the `SignetsApiClient` class. You will first need to import the clients file from the package. Then, call any function that you whish to use.
+To use this library you can create an instance of the `SignetsApiClient` class. You will first need to import the clients file from the package. Then, call any function that you wish to use.
 
 ```dart
 

--- a/lib/src/models/course_evaluation.dart
+++ b/lib/src/models/course_evaluation.dart
@@ -49,14 +49,10 @@ class CourseEvaluation {
 
   /// Weighted grade of the evaluation
   /// (ex: Mark of 25/50 and 10% weight => 5/10 weighted grade)
-  double? get weightedGrade {
-    double? result = mark == null ||
-            correctedEvaluationOutOfFormatted == 0.0 ||
-            weight == 0.0
-        ? null
-        : (mark! / correctedEvaluationOutOfFormatted) * weight;
-    return result != null ? double.parse(result.toStringAsFixed(2)) : null;
-  }
+  double? get weightedGrade =>
+      mark == null || correctedEvaluationOutOfFormatted == 0.0 || weight == 0.0
+          ? null
+          : (mark! / correctedEvaluationOutOfFormatted) * weight;
 
   CourseEvaluation(
       {required this.courseGroup,

--- a/lib/src/models/course_evaluation.dart
+++ b/lib/src/models/course_evaluation.dart
@@ -50,7 +50,7 @@ class CourseEvaluation {
   /// Weighted grade of the evaluation
   /// (ex: Mark of 25/50 and 10% weight => 5/10 weighted grade)
   double? get weightedGrade {
-    double? result = (mark ?? 0.0) == 0.0 ||
+    double? result = mark == null ||
             correctedEvaluationOutOfFormatted == 0.0 ||
             weight == 0.0
         ? null

--- a/lib/src/models/course_evaluation.dart
+++ b/lib/src/models/course_evaluation.dart
@@ -47,6 +47,17 @@ class CourseEvaluation {
 
   double get markInPercent => mark! / correctedEvaluationOutOfFormatted;
 
+  /// Weighted grade of the evaluation
+  /// (ex: Mark of 25/50 and 10% weight => 5/10 weighted grade)
+  double get weightedGrade {
+    double result = (mark ?? 0.0) == 0.0 ||
+            correctedEvaluationOutOfFormatted == 0.0 ||
+            weight == 0.0
+        ? 0.0
+        : (mark! / correctedEvaluationOutOfFormatted) * weight;
+    return double.parse(result.toStringAsFixed(2));
+  }
+
   CourseEvaluation(
       {required this.courseGroup,
       required this.title,

--- a/lib/src/models/course_evaluation.dart
+++ b/lib/src/models/course_evaluation.dart
@@ -49,13 +49,13 @@ class CourseEvaluation {
 
   /// Weighted grade of the evaluation
   /// (ex: Mark of 25/50 and 10% weight => 5/10 weighted grade)
-  double get weightedGrade {
-    double result = (mark ?? 0.0) == 0.0 ||
+  double? get weightedGrade {
+    double? result = (mark ?? 0.0) == 0.0 ||
             correctedEvaluationOutOfFormatted == 0.0 ||
             weight == 0.0
-        ? 0.0
+        ? null
         : (mark! / correctedEvaluationOutOfFormatted) * weight;
-    return double.parse(result.toStringAsFixed(2));
+    return result != null ? double.parse(result.toStringAsFixed(2)) : null;
   }
 
   CourseEvaluation(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ets_api_clients
 description: API clients to help process calls from any application that need to access
-version: 1.1.7
+version: 1.2.0
 
 homepage: https://clubapplets.ca/
 repository: https://github.com/ApplETS/ETS-API-Clients

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ets_api_clients
-description: API clients to help process calls from any application that need to access 
-version: 1.1.6
+description: API clients to help process calls from any application that need to access
+version: 1.1.7
 
 homepage: https://clubapplets.ca/
 repository: https://github.com/ApplETS/ETS-API-Clients
@@ -9,7 +9,6 @@ documentation: https://github.com/ApplETS/ETS-API-Clients
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-
 
 dependencies:
   xml: ^6.4.2

--- a/test/signets_api_client_test.dart
+++ b/test/signets_api_client_test.dart
@@ -1,4 +1,6 @@
 // FLUTTER / DART / THIRD-PARTIES
+import 'dart:math';
+
 import 'package:ets_api_clients/clients.dart';
 import 'package:ets_api_clients/exceptions.dart';
 import 'package:ets_api_clients/src/constants/urls.dart';
@@ -726,6 +728,9 @@ void main() {
 
         expect(result, isA<CourseSummary>());
         expect(result, courseSummary);
+
+        expect(result.evaluations[0].weightedGrade, 0.0);
+        expect(result.evaluations[1].weightedGrade, 9.0);
       });
 
       test("Summary is empty", () async {

--- a/test/signets_api_client_test.dart
+++ b/test/signets_api_client_test.dart
@@ -1,6 +1,4 @@
 // FLUTTER / DART / THIRD-PARTIES
-import 'dart:math';
-
 import 'package:ets_api_clients/clients.dart';
 import 'package:ets_api_clients/exceptions.dart';
 import 'package:ets_api_clients/src/constants/urls.dart';

--- a/test/signets_api_client_test.dart
+++ b/test/signets_api_client_test.dart
@@ -727,7 +727,7 @@ void main() {
         expect(result, isA<CourseSummary>());
         expect(result, courseSummary);
 
-        expect(result.evaluations[0].weightedGrade, 0.0);
+        expect(result.evaluations[0].weightedGrade, null);
         expect(result.evaluations[1].weightedGrade, 9.0);
       });
 


### PR DESCRIPTION
## Closes
#27 

## Description

This PR implements `weightedGrade` as part of `CourseEvaluation`. This way, we don't need to calculate it in Notre-Dame, more specifically in https://github.com/ApplETS/Notre-Dame/pull/921

## Testing
I modified 2 tests to also check the `weightedGrade`. 
I hard-coded the expected values. It's not my preferred way but there are already a lot of hard-coded values and if they don't change, I suppose it's alright.