### PR TITLE
Store list of CourseReview in Course model

### DIFF
--- a/lib/src/models/course.dart
+++ b/lib/src/models/course.dart
@@ -52,7 +52,7 @@ class Course {
         now.isBefore(reviews!.first.endAt);
   }
 
-  /// Determine if the review of this course is completed.
+  /// Determine if all the reviews of this course are completed.
   bool? get allReviewsCompleted {
     if (reviews == null) {
       return true;

--- a/lib/src/models/course.dart
+++ b/lib/src/models/course.dart
@@ -1,4 +1,5 @@
 // FLUTTER / DART / THIRD-PARTIES
+import 'package:collection/collection.dart';
 import 'package:xml/xml.dart';
 
 import 'course_review.dart';
@@ -34,28 +35,29 @@ class Course {
   CourseSummary? summary;
 
   /// Information about when the course will be evaluated by the student.
-  CourseReview? review;
+  List<CourseReview>? reviews;
 
   /// Get the teacher name if available
-  String? get teacherName => review?.teacherName;
+  String? get teacherName => reviews?.first.teacherName;
 
   /// Determine if we are currently in the review period for this course.
   bool get inReviewPeriod {
-    if (review == null) {
+    if (reviews == null) {
       return false;
     }
 
     final now = DateTime.now();
 
-    return now.isAfter(review!.startAt) && now.isBefore(review!.endAt);
+    return now.isAfter(reviews!.first.startAt) &&
+        now.isBefore(reviews!.first.endAt);
   }
 
   /// Determine if the review of this course is completed.
-  bool? get reviewCompleted {
-    if (review == null) {
+  bool? get allReviewsCompleted {
+    if (reviews == null) {
       return true;
     }
-    return review!.isCompleted;
+    return reviews!.every((review) => review.isCompleted);
   }
 
   Course(
@@ -67,7 +69,7 @@ class Course {
       required this.numberOfCredits,
       this.grade,
       this.summary,
-      this.review});
+      this.reviews});
 
   /// Used to create a new [Course] instance from a [XMLElement].
   factory Course.fromXmlNode(XmlElement node) => Course(
@@ -93,8 +95,11 @@ class Course {
       summary: map["summary"] != null
           ? CourseSummary.fromJson(map["summary"] as Map<String, dynamic>)
           : null,
-      review: map["review"] != null
-          ? CourseReview.fromJson(map["review"] as Map<String, dynamic>)
+      reviews: map["review"] != null
+          ? (map["review"] as List)
+              .map(
+                  (item) => CourseReview.fromJson(item as Map<String, dynamic>))
+              .toList()
           : null);
 
   Map<String, dynamic> toJson() => {
@@ -106,7 +111,7 @@ class Course {
         'numberOfCredits': numberOfCredits,
         'grade': grade,
         'summary': summary,
-        'review': review
+        'reviews': reviews
       };
 
   @override
@@ -120,7 +125,7 @@ class Course {
         'grade: $grade, '
         'numberOfCredits: $numberOfCredits, '
         'summary: $summary, '
-        'review: $review}';
+        'reviews: $reviews}';
   }
 
   @override
@@ -136,7 +141,7 @@ class Course {
           grade == other.grade &&
           numberOfCredits == other.numberOfCredits &&
           summary == other.summary &&
-          review == other.review;
+          const ListEquality().equals(reviews, other.reviews);
 
   @override
   int get hashCode =>
@@ -148,5 +153,5 @@ class Course {
       grade.hashCode ^
       numberOfCredits.hashCode ^
       summary.hashCode ^
-      review.hashCode;
+      reviews.hashCode;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ets_api_clients
 
 description: API clients to help process calls from any application that need to access
-version: 1.2.4
+version: 1.2.5
 
 homepage: https://clubapplets.ca/
 repository: https://github.com/ApplETS/ETS-API-Clients

--- a/test/signets_api_client_test.dart
+++ b/test/signets_api_client_test.dart
@@ -784,6 +784,16 @@ void main() {
           '<EstComplete>true</EstComplete> '
           '</EvaluationCours>';
 
+      const String incompleteCourseReviewForSameCourseXML = '<EvaluationCours> '
+          '<Sigle>GEN101</Sigle> '
+          '<Groupe>01</Groupe> '
+          '<Enseignant>Another, Teacher</Enseignant> '
+          '<DateDebutEvaluation>2021-03-19T00:00:00</DateDebutEvaluation> '
+          '<DateFinEvaluation>2021-03-28T23:59:00</DateFinEvaluation> '
+          '<TypeEvaluation>Cours</TypeEvaluation> '
+          '<EstComplete>false</EstComplete> '
+          '</EvaluationCours>';
+
       const String courseReviewNotCompletedXML = '<EvaluationCours> '
           '<Sigle>GEN102</Sigle> '
           '<Groupe>01</Groupe> '
@@ -803,6 +813,15 @@ void main() {
           type: 'Cours',
           isCompleted: true);
 
+      final CourseReview incompleteCourseReviewForSameCourse = CourseReview(
+          acronym: 'GEN101',
+          group: '01',
+          teacherName: 'Another, Teacher',
+          startAt: DateTime(2021, 03, 19),
+          endAt: DateTime(2021, 03, 28, 23, 59),
+          type: 'Cours',
+          isCompleted: false);
+
       final CourseReview courseReviewNotCompleted = CourseReview(
           acronym: 'GEN102',
           group: '01',
@@ -818,7 +837,9 @@ void main() {
 
         final String stubResponse = buildResponse(
             Urls.readCourseReviewOperation,
-            courseReviewCompletedXML + courseReviewNotCompletedXML,
+            courseReviewCompletedXML +
+                incompleteCourseReviewForSameCourseXML +
+                courseReviewNotCompletedXML,
             'liste');
 
         clientMock =
@@ -829,8 +850,13 @@ void main() {
             username: username, password: password, session: session);
 
         expect(result, isA<List<CourseReview>>());
-        expect(result,
-            containsAll([courseReviewCompleted, courseReviewNotCompleted]));
+        expect(
+            result,
+            containsAll([
+              courseReviewCompleted,
+              incompleteCourseReviewForSameCourse,
+              courseReviewNotCompleted
+            ]));
       });
 
       // Currently SignetsAPI doesn't have a clear way to indicate which error


### PR DESCRIPTION
## Issue
#35 

## Description

The `Course` model can now store a list of `CourseReview` instead of just one `CourseReview`.

## Testing

I added some course evaluation XML to `group("getCoursesEvaluation - ")` to simulate the fact that there's another course evaluation for a different teacher for the same course.

It seems like in this project, we don't do much testing on the models themselves so should do for now.

*There will be more thorough testing in Notre-Dame.*